### PR TITLE
Allow relative IRI in Oxiri

### DIFF
--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use oxiri::Iri;
+use oxiri::{Iri, IriRef};
 
 fn abs_examples() -> &'static [&'static str] {
     &[
@@ -41,10 +41,10 @@ fn bench_iri_parse(c: &mut Criterion) {
 }
 
 fn bench_iri_parse_relative(c: &mut Criterion) {
-    c.bench_function("Iri::parse_relative", |b| {
+    c.bench_function("IriRef::parse", |b| {
         b.iter(|| {
             for iri in abs_examples().iter() {
-                Iri::parse_relative(*iri).unwrap();
+                IriRef::parse(*iri).unwrap();
             }
         })
     });

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -1,8 +1,8 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use oxiri::Iri;
 
-fn bench_iri_parse(c: &mut Criterion) {
-    let examples = [
+fn abs_examples() -> &'static [&'static str] {
+    &[
         "file://foo",
         "ftp://ftp.is.co.za/rfc/rfc1808.txt",
         "http://www.ietf.org/rfc/rfc2396.txt",
@@ -27,12 +27,24 @@ fn bench_iri_parse(c: &mut Criterion) {
         "http://example.com/foo/bar?q=1&r=2#toto",
         "http://example.com/foo/bar/?q=1&r=2#toto",
         "http://example.com/foo/bar/.././baz",
-    ];
+    ]
+}
 
-    c.bench_function("w3c parse tests", |b| {
+fn bench_iri_parse(c: &mut Criterion) {
+    c.bench_function("Iri::parse", |b| {
         b.iter(|| {
-            for iri in examples.iter() {
+            for iri in abs_examples().iter() {
                 Iri::parse(*iri).unwrap();
+            }
+        })
+    });
+}
+
+fn bench_iri_parse_relative(c: &mut Criterion) {
+    c.bench_function("Iri::parse_relative", |b| {
+        b.iter(|| {
+            for iri in abs_examples().iter() {
+                Iri::parse_relative(*iri).unwrap();
             }
         })
     });
@@ -88,7 +100,7 @@ fn bench_iri_resolve(c: &mut Criterion) {
     let base = Iri::parse("http://a/b/c/d;p?q").unwrap();
 
     let mut buf = String::new();
-    c.bench_function("w3c resolve tests", |b| {
+    c.bench_function("Iri::resolve_into", |b| {
         b.iter(|| {
             for relative in examples.iter() {
                 buf.clear();
@@ -98,6 +110,11 @@ fn bench_iri_resolve(c: &mut Criterion) {
     });
 }
 
-criterion_group!(iri, bench_iri_parse, bench_iri_resolve);
+criterion_group!(
+    iri,
+    bench_iri_parse,
+    bench_iri_parse_relative,
+    bench_iri_resolve
+);
 
 criterion_main!(iri);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 //! assert_eq!(iri.as_str(), "http://foo.com/bar/bat#foo");
 //!
 //! // Extract IRI components
-//! assert_eq!(iri.scheme(), "http");
+//! assert_eq!(iri.scheme(), Some("http"));
 //! assert_eq!(iri.authority(), Some("foo.com"));
 //! assert_eq!(iri.path(), "/bar/bat");
 //! assert_eq!(iri.query(), None);
@@ -144,25 +144,25 @@ impl<T: Deref<Target = str>> Iri<T> {
         self.positions.scheme_end != 0
     }
 
-    /// Returns the IRI scheme.
+    /// Returns the IRI scheme if it exists.
     ///
     /// Beware: the scheme case is not normalized. Use case insensitive comparisons if you look for a specific scheme.
     ///
-    /// Beware also that the scheme may be empty if this Iri is relative
+    /// NB: only relative IRI references have no scheme
     /// (see [`Iri::parse_relative`] and [`Iri::is_absolute`]).
     ///
     /// ```
     /// use oxiri::Iri;
     ///
     /// let iri = Iri::parse("hTTp://example.com").unwrap();
-    /// assert_eq!("hTTp", iri.scheme());
+    /// assert_eq!(Some("hTTp"), iri.scheme());
     /// ```
     #[inline]
-    pub fn scheme(&self) -> &str {
+    pub fn scheme(&self) -> Option<&str> {
         if self.positions.scheme_end == 0 {
-            ""
+            None
         } else {
-            &self.iri[..self.positions.scheme_end - 1]
+            Some(&self.iri[..self.positions.scheme_end - 1])
         }
     }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -128,6 +128,9 @@ fn test_relative_parsing() {
 
     let base = Iri::parse("http://a/b/c/d;p?q").unwrap();
     for e in examples.iter() {
+        if let Err(error) = Iri::parse_relative(*e) {
+            panic!("{} on relative IRI {}", error, e);
+        }
         if let Err(error) = base.resolve(*e) {
             panic!("{} on relative IRI {}", error, e);
         }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::eq_op)]
-use oxiri::Iri;
+use oxiri::{Iri, IriRef};
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 
@@ -128,7 +128,7 @@ fn test_relative_parsing() {
 
     let base = Iri::parse("http://a/b/c/d;p?q").unwrap();
     for e in examples.iter() {
-        if let Err(error) = Iri::parse_relative(*e) {
+        if let Err(error) = IriRef::parse(*e) {
             panic!("{} on relative IRI {}", error, e);
         }
         if let Err(error) = base.resolve(*e) {


### PR DESCRIPTION
I am currently refactoring [Sophia](https://github.com/pchampin/sophia_rs), and I would like to use `oxiri` instead of my old IRI resolution algorithm (which is much slower).
However, in Sophia, I need to be able to resolve IRIs against a *relative* base.

This PR extends `oxiri::Iri` with the ability to parse, and resolve against, relative IRIs.
Note that this does not change the current behaviour of `Iri::parse`: it still expects absolute IRIs and errs if a relative IRI is given. A new method `Iri::parse_relative` must be explicitly used to accept relative IRIs. Note also that it does not seem to impact performances.

There are however some slightly breaking changes
- now `scheme` returns an option (not absolutely necessary, but that's more consisten with the rest of the API),
- some code may assume that an `Iri` always contains an *absolute* IRI, which would not be the case anymore.

Assuming that you are ok with the general idea, but that the breaking changes above are not acceptable, I can propose an alternative. Instead of allowing relative IRIs in `Iri`, I can create alternative type `IriRef` that would work similarly to `Iri`, but allow relative IRIs. My version of `IriParser` supports both, so that should not be too hard, but that would lead to a big duplication of code between `Iri` and `IriRef`.

Yet another alternative would be to add a generic parameter to `Iri<T, MODE>`, where only two types could be used for MODE (one meaning "absolute", and the other one meaning "relative"). MODE could have a default value, so that `Iri<T>` would still be limited to absolute IRIs, and `Iri<T, Relative>` would allow for relative IRIs.
